### PR TITLE
test: clarify object property subscription

### DIFF
--- a/__test__/unit/object.test.js
+++ b/__test__/unit/object.test.js
@@ -8,74 +8,74 @@ describe('almy with objects', () => {
   test('WhenDispatchedWithAnObjectShouldSaveThatObjectInTheState', () => {
     almy.dispatch('video', {
       src: 'https://video.com/vid.mp4',
-      volume: 45
+      volume: 45,
     });
 
     expect({
       src: 'https://video.com/vid.mp4',
-      volume: 45
+      volume: 45,
     }).toEqual(almy.state('video'));
   });
 
-  test('WhenListenOverObjectShouldReceiveThatObjectFromTheState', done => {
+  test('WhenListenOverObjectShouldReceiveThatObjectFromTheState', (done) => {
     almy.dispatch('video', {
       src: 'https://video.com/vid.mp4',
-      volume: 45
+      volume: 45,
     });
 
-    almy.subscribe('video', state => {
+    almy.subscribe('video', (state) => {
       expect({
         src: 'https://video.com/vid.mp4',
-        volume: 45
+        volume: 45,
       }).toEqual(state);
       done();
     });
   });
 
-  test('WhenListenOnPropertyOfObjectShouldReceiveThatPropertyFromTheState', done => {
+  test('WhenListenOnPropertyOfObjectShouldReceiveThatPropertyFromTheState', (done) => {
     almy.dispatch('video', {
       src: 'https://video.com/vid.mp4',
-      volume: 45
+      volume: 45,
     });
 
-    almy.subscribe('video->volume', volume => {
+    almy.subscribe('video->volume', (volume) => {
       expect(45).toEqual(volume);
       done();
     });
   });
 
-  test('WhenBeforeListenOnPropertyOfObjectShouldReceiveThatPropertyFromTheState', done => {
-    almy.subscribe('video->volume', volume => {
+  test('WhenBeforeListenOnPropertyOfObjectShouldReceiveThatPropertyFromTheState', (done) => {
+    almy.subscribe('video->volume', (volume) => {
       expect(45).toEqual(volume);
       done();
     });
 
     almy.dispatch('video', {
       src: 'https://video.com/vid.mp4',
-      volume: 45
+      volume: 45,
     });
   });
 
-  test('WhenDispatchedPropertyOfObjectShouldReceiveThatPropertyFromTheState', done => {
+  test('WhenDispatchedPropertyOfObjectShouldReceiveThatPropertyFromTheState', (done) => {
     almy.dispatch('video->src', 'https://video.com/vid.mp4');
 
-    almy.subscribe('video->src', src => {
+    almy.subscribe('video->src', (src) => {
       expect('https://video.com/vid.mp4').toEqual(src);
       done();
     });
   });
 
-  test('WhenDispatchedPropertyOfObjectShouldReceiveTheObjectFromTheState', done => {
+  test('WhenDispatchedPropertyOfObjectShouldReceiveTheObjectFromTheState', (done) => {
     almy.dispatch('video->src', 'https://video.com/vid.mp4');
 
-    almy.subscribe('video', video => {
+    almy.subscribe('video', (video) => {
       expect({ src: 'https://video.com/vid.mp4' }).toEqual(video);
       done();
     });
   });
 
-  test('WhenDispatchedTWICETheSamePropertyValueOfObjectShouldOnlyReceiveOnce', done => {
-    almy.subscribe('video', video => {
+  test('WhenDispatchedTWICETheSamePropertyValueOfObjectShouldOnlyReceiveOnce', (done) => {
+    almy.subscribe('video', (video) => {
       expect({ src: 'https://video.com/vid_1.mp4' }).toEqual(video);
       // done call will fail if called twice
       done();
@@ -84,9 +84,9 @@ describe('almy with objects', () => {
     almy.dispatch('video->src', 'https://video.com/vid_1.mp4');
   });
 
-  test('WhenDispatchedPropertyWithObjectSetShouldReceiveProperty', done => {
+  test('WhenDispatchedPropertyWithObjectSetShouldReceiveProperty', (done) => {
     let times = 0;
-    almy.subscribe('image', image => {
+    almy.subscribe('image', (image) => {
       switch (times) {
         case 0:
           expect(image).toEqual({ href: 'https://video.com/1.mp4' });
@@ -102,9 +102,9 @@ describe('almy with objects', () => {
     almy.dispatch('image->href', 'https://image.com/2.jpg');
   });
 
-  test('WhenReverseDispatchedPropertyWithObjectSetShouldReceiveProperty', done => {
+  test('WhenReverseDispatchedPropertyWithObjectSetShouldReceiveProperty', (done) => {
     let times = 0;
-    almy.subscribe('video', video => {
+    almy.subscribe('video', (video) => {
       switch (times) {
         case 0:
           expect({ src: 'https://video.com/vid_2.mp4' }).toEqual(video);
@@ -120,19 +120,19 @@ describe('almy with objects', () => {
     almy.dispatch('video', { src: 'https://video.com/vid_1.mp4' });
   });
 
-  test('WhenDispatchedAnObjectWithNotOwnedPropertiesShouldNotDispatchThoseProperties', done => {
-    almy.subscribe('list->addToList', function() {
+  test('WhenDispatchedAnObjectWithNotOwnedPropertiesShouldNotDispatchThoseProperties', (done) => {
+    almy.subscribe('list->addToList', function () {
       done(new Error('Not expected to be called'));
     });
-    almy.subscribe('list->ownedProperty', function(value) {
+    almy.subscribe('list->ownedProperty', function (value) {
       setTimeout(() => {
         expect(value).toEqual('mine');
         done();
       }, 0);
     });
 
-    const List = function() {};
-    List.prototype.addToList = function(elem, value) {
+    const List = function () {};
+    List.prototype.addToList = function (elem, value) {
       this[elem] = value;
     };
 
@@ -143,12 +143,12 @@ describe('almy with objects', () => {
     almy.dispatch('list', instance);
   });
 
-  test('WhenDispatchedArraysShouldReceiveThem', done => {
-    almy.subscribe('video', video => {
+  test('WhenDispatchedArraysShouldReceiveThem', (done) => {
+    almy.subscribe('video', (video) => {
       expect(video.src).toEqual([
         'https://video.com/vid_1.mp4',
         'https://video.com/vid_2.mp4',
-        'https://video.com/vid_3.mp4'
+        'https://video.com/vid_3.mp4',
       ]);
       done();
     });
@@ -156,32 +156,31 @@ describe('almy with objects', () => {
       src: [
         'https://video.com/vid_1.mp4',
         'https://video.com/vid_2.mp4',
-        'https://video.com/vid_3.mp4'
-      ]
+        'https://video.com/vid_3.mp4',
+      ],
     });
   });
 
-  test('WhenSubscribedToArrayPositionShouldReceiveThatPosition', done => {
-    almy.subscribe('video_urls->2', url => {
+  test('WhenSubscribedToArrayPositionShouldReceiveThatPosition', (done) => {
+    almy.subscribe('video_urls->2', (url) => {
       expect(url).toEqual('https://video.com/vid_3.mp4');
       done();
     });
     almy.dispatch('video_urls', [
       'https://video.com/vid_1.mp4',
       'https://video.com/vid_2.mp4',
-      'https://video.com/vid_3.mp4'
+      'https://video.com/vid_3.mp4',
     ]);
   });
 
-  test('WhenSubscribedToArrayPositionShouldReceiveThatPosition', done => {
+  test('WhenSubscribedToObjectPropertyShouldReceiveThatProperty', (done) => {
     almy.dispatch('user', { favorites: { televisions: { '4k': true } } });
 
-    almy.subscribe('user->favorites', favorites => {
+    almy.subscribe('user->favorites', (favorites) => {
       expect(favorites.televisions['4k']).toEqual(true);
       done();
     });
   });
-
 
   // TODO: fix deep subscription for objects
   // test('WhenSubscribedToArrayPositionShouldReceiveThatPosition', done => {


### PR DESCRIPTION
## Summary
- clarify unit test title to match object property subscription behavior

## Testing
- `npm test` *(fails: rollup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c58161890832db8ad5e8ea108623a