### PR TITLE
Fix subscribe presence check

### DIFF
--- a/__test__/unit/primitive.test.js
+++ b/__test__/unit/primitive.test.js
@@ -60,7 +60,7 @@ describe('almy with primitives', () => {
     almy.subscribe('VideoVolume', checkValueAndCall(done, 56));
   });
 
-  test('subscribeWhenCalledWithStateSetToZeroShouldBeCalledBackImmediately', done => {
+  test('subscribeWhenCalledWithStateSetToZeroShouldBeCalledBackImmediately', (done) => {
     almy.dispatch('VideoVolume', 0);
     almy.subscribe('VideoVolume', checkValueAndCall(done, 0));
   });

--- a/__test__/unit/primitive.test.js
+++ b/__test__/unit/primitive.test.js
@@ -60,6 +60,11 @@ describe('almy with primitives', () => {
     almy.subscribe('VideoVolume', checkValueAndCall(done, 56));
   });
 
+  test('subscribeWhenCalledWithStateSetToZeroShouldBeCalledBackImmediately', done => {
+    almy.dispatch('VideoVolume', 0);
+    almy.subscribe('VideoVolume', checkValueAndCall(done, 0));
+  });
+
   test('subscribeWhenCalledMultipleTimesShouldCallAllListeners', (done) => {
     const firstListener = new Promise((resolve) =>
       almy.subscribe('VideoVolume', checkValueAndCall(resolve, 56))

--- a/almy.js
+++ b/almy.js
@@ -41,7 +41,7 @@ var almy = {
   subscribe: function(key, callback) {
     if (!listeners[key]) listeners[key] = [];
     listeners[key].push(callback);
-    if (state[key]) callback(state[key]);
+    if (Object.prototype.hasOwnProperty.call(state, key)) callback(state[key]);
   }
 };
 export { almy };


### PR DESCRIPTION
## Summary
- ensure subscriptions fire for falsy values by checking key presence instead of truthiness
- add regression test for zero value subscriptions

## Testing
- `npm --ignore-scripts test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5812e954832da6a860122814ddcf