### PR TITLE
feat: add unsubscribe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ npm install --save almy
 ## Methods
 -  **dispatch(key: string, value: any)**    
 _Dispatches some event that happened in a key value fashion_
--  **subscribe(key: string, callback: Function)**   
-_Subscribes to dispatched events. If someone has dispatched an event before, it calls the callback right away_
+-  **subscribe(key: string, callback: Function): Function**
+_Subscribes to dispatched events. If someone has dispatched an event before, it calls the callback right away. Returns a function to unsubscribe the listener_
 -  **state(key:?string):any**    
 _Returns the state of your application_
 
@@ -162,8 +162,8 @@ Keys use a `key->property` convention for nested paths.
 
 dispatch avoids redundant notifications by comparing against the current state.
 
-subscribe does not support unsubscribe out of the box; listeners accumulate unless
-manually reset via create().
+subscribe returns an unsubscribe function so listeners can be removed without
+resetting the store.
 
 The repository currently exposes only the built files (dist/*) when published to npm
 (files field in package.json).

--- a/__test__/unit/primitive.test.js
+++ b/__test__/unit/primitive.test.js
@@ -83,6 +83,16 @@ describe('almy with primitives', () => {
       .catch((e) => done(e));
   });
 
+  test('unsubscribeShouldRemoveListener', () => {
+    const callback = jest.fn();
+    const unsubscribe = almy.subscribe('VideoVolume', callback);
+    almy.dispatch('VideoVolume', 56);
+    expect(callback).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    almy.dispatch('VideoVolume', 100);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   function checkValueAndCall(done, shouldBe = 56) {
     return (newVolume) => {
       try {

--- a/almy.js
+++ b/almy.js
@@ -62,6 +62,16 @@ var almy = {
     if (!listeners[key]) listeners[key] = [];
     listeners[key].push(callback);
     if (Object.hasOwn(state, key)) callback(state[key]);
+    return function () {
+      if (!listeners[key]) return;
+      var index = listeners[key].indexOf(callback);
+      if (index !== -1) {
+        listeners[key].splice(index, 1);
+        if (listeners[key].length === 0) {
+          delete listeners[key];
+        }
+      }
+    };
   },
 };
 export { almy };


### PR DESCRIPTION
## Summary
- allow `subscribe` to return an unsubscribe function
- document unsubscribe capability in README
- ensure callbacks removed by unsubscribe are not triggered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a42c2da6c0832d96a637c6ae774f1f