### PR TITLE
refactor: make dispatch context-free and add test

### DIFF
--- a/__test__/unit/standalone-dispatch.test.js
+++ b/__test__/unit/standalone-dispatch.test.js
@@ -1,0 +1,10 @@
+describe('standalone dispatch', () => {
+  test('works when destructured', () => {
+    const { almy } = require('../..');
+    almy.create();
+    const { dispatch } = require('../..').almy;
+    dispatch('k', 1);
+    dispatch('k', { inner: 1 });
+    expect(almy.state('k->inner')).toBe(1);
+  });
+});

--- a/almy.js
+++ b/almy.js
@@ -8,7 +8,7 @@ var almy = {
   state: function (key) {
     return key ? state[key] : state;
   },
-  dispatch: function (
+  dispatch: function dispatch(
     key,
     value,
     skipOptimization,
@@ -33,7 +33,7 @@ var almy = {
     if (typeof value === 'object' && value !== null && !skipDownPropagation) {
       for (var prop in value) {
         if (Object.prototype.hasOwnProperty.call(value, prop)) {
-          this.dispatch(
+          dispatch(
             key + '->' + prop,
             value[prop],
             skipOptimization,
@@ -53,7 +53,7 @@ var almy = {
           state[parentKey] = {};
         }
         state[parentKey][child] = value;
-        this.dispatch(parentKey, state[parentKey], true, true, false);
+        dispatch(parentKey, state[parentKey], true, true, false);
       }
     }
   },


### PR DESCRIPTION
## Summary
- make `dispatch` self-referential to remove `this` context dependence
- add test ensuring `dispatch` works when destructured

## Testing
- `npx prettier --write almy.js __test__/**/*.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a436b84880832daf8c4505d3166610