### PR TITLE
docs: use GitHub Actions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🗄️ almy
 
 [![Version](https://badgen.net/npm/v/almy)](https://www.npmjs.com/package/almy)
-[![Build Status](https://travis-ci.org/tomas2387/almy.svg?branch=master)](https://travis-ci.org/tomas2387/almy)
-[![Coverage Status](https://coveralls.io/repos/github/tomas2387/almy/badge.svg?branch=master)](https://coveralls.io/github/tomas2387/almy?branch=master)
+[![CI](https://github.com/tomas2387/almy/actions/workflows/test.yml/badge.svg)](https://github.com/tomas2387/almy/actions/workflows/test.yml)
+[![Coverage](https://codecov.io/gh/tomas2387/almy/branch/master/graph/badge.svg)](https://codecov.io/gh/tomas2387/almy)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/almy)
 
 The simplest store for managing the state in your application.  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version](https://badgen.net/npm/v/almy)](https://www.npmjs.com/package/almy)
 [![CI](https://github.com/tomas2387/almy/actions/workflows/test.yml/badge.svg)](https://github.com/tomas2387/almy/actions/workflows/test.yml)
 [![Coverage](https://codecov.io/gh/tomas2387/almy/branch/master/graph/badge.svg)](https://codecov.io/gh/tomas2387/almy)
-![npm bundle size](https://img.shields.io/bundlephobia/minzip/almy)
+![install size](https://packagephobia.com/badge?p=almy@2.0.0)
 
 The simplest store for managing the state in your application.  
 Works in all environments and all browsers.


### PR DESCRIPTION
## Summary
- replace Travis and Coveralls badges with GitHub Actions CI and Codecov coverage badges

## Testing
- `npx prettier --write README.md`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a490cbe8e4832d9435042f50d15002